### PR TITLE
documentation - change user to group

### DIFF
--- a/playbooks/roles/cluster-cli/files/cluster
+++ b/playbooks/roles/cluster-cli/files/cluster
@@ -136,7 +136,7 @@ def create(group, gid):
 @group.command()
 @click.argument('group')
 def delete(group):
-  """ delete user """
+  """ delete group """
   search_base = groups_dn
   server = ldap3.Server(host, use_ssl=True)
   with ldap3.Connection(server, bind_dn, bind_pass, auto_bind=True) as conn:


### PR DESCRIPTION
The documentation in the `cluster` command is incorrect. When executing `cluster group --help` the output says that the `cluster group delete` command deletes a user which it does not. The command deletes a group.