### PR TITLE
Install snapd

### DIFF
--- a/playbooks/roles/cais-all/tasks/ol-7.yml
+++ b/playbooks/roles/cais-all/tasks/ol-7.yml
@@ -28,3 +28,35 @@
   include_role: 
     name: safe_yum
   ignore_errors: true
+
+# Install snap
+- name: Install snapd
+  vars: 
+    package_name: 
+      - snapd
+    package_state: latest
+    package_repo: "epel,ol7_developer_EPEL"
+  include_role: 
+    name: safe_yum
+  ignore_errors: true
+
+- name: Stop snapd socket if it exists
+  become: true
+  ansible.builtin.systemd:
+    name: snapd.socket
+    state: stopped
+- name: Enable service snapd
+  become: true
+  ansible.builtin.systemd:
+    name: snapd.service
+    state: started
+    enabled: true
+    masked: no
+- name: Create a symbolic link for snap
+  become: true
+  ansible.builtin.file:
+    src: /var/lib/snapd/snap
+    dest: /snap
+    owner: root
+    group: root
+    state: link


### PR DESCRIPTION
Installing snap to allow for more easy installation of certain packages.

Tests on cluster:

```
ansible-playbook cais_all.yml

...

TASK [Install snapd] ***********************************************************

TASK [safe_yum : yum first try [u'snapd']] *************************************
ok: [inst-yty8g-tight-caribou]
ok: [inst-jnker-tight-caribou]
ok: [tight-caribou-login]
ok: [tight-caribou-bastion]

TASK [safe_yum : Check on an async yum task] ***********************************
ok: [inst-yty8g-tight-caribou]
ok: [inst-jnker-tight-caribou]
ok: [tight-caribou-login]
ok: [tight-caribou-bastion]

...

TASK [cais-all : Enable service snapd] *****************************************
ok: [inst-jnker-tight-caribou]
ok: [inst-yty8g-tight-caribou]
ok: [tight-caribou-login]
ok: [tight-caribou-bastion]

TASK [cais-all : Create a symbolic link for snap] ******************************
ok: [inst-jnker-tight-caribou]
ok: [inst-yty8g-tight-caribou]
changed: [tight-caribou-login]
changed: [tight-caribou-bastion]

LAY RECAP *********************************************************************
inst-jnker-tight-caribou   : ok=11   changed=0    unreachable=0    failed=0    skipped=23   rescued=0    ignored=0   
inst-yty8g-tight-caribou   : ok=11   changed=0    unreachable=0    failed=0    skipped=23   rescued=0    ignored=0   
tight-caribou-bastion      : ok=11   changed=1    unreachable=0    failed=0    skipped=23   rescued=0    ignored=0   
tight-caribou-login        : ok=11   changed=1    unreachable=0    failed=0    skipped=23   rescued=0    ignored=0
```

Confirming it works
```
$ snap --version
snap    2.58.3-1.el7
snapd   2.58.3-1.el7
series  16
ol      7.9
kernel  3.10.0-1160.76.1.0.1.el7.x86_64
```