### PR TITLE
55 add nix package manager

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,3 @@
+To install the Nix package manager run the install_nix.yml playbook.
+To remove the Nix package manager run the uninstall_nix.yml playbook.
+Both playbooks are idempotent. If you get an error running the uninstall_nix.yml playbook rerun the playbook. 

--- a/playbooks/install_nix.yml
+++ b/playbooks/install_nix.yml
@@ -1,0 +1,191 @@
+---
+
+- name: Get nix version
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - shell: |
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+        nix --version
+      ignore_errors: true
+      changed_when: false
+      register: nix_version_output
+    - name: Set nix version name
+      set_fact:
+        nix_version_on_system: "{{ (nix_version_output.stdout_lines[0].split(' '))[2] }}"
+      when: nix_version_output.rc == 0
+    - name: Prompt user if Nix is installed
+      debug:
+        msg: "WARNING! Nix is already installed. Stopping playbook."
+      when: nix_version_on_system is defined
+    - name: Stop play if Nix is installed
+      fail: 
+      when: nix_version_on_system is defined
+
+# setup environment for nix
+- name: Ensure /data/nix/var/nix/ dir exists
+  hosts: bastion 
+  become: true
+  tasks:
+    - name: Check if directory exists
+      stat:
+        path: /data/nix/var/nix/ 
+      register: dir_stat
+    - name: Create directory
+      file:
+        path: /data/nix/var/nix/ 
+        state: directory
+      when: not dir_stat.stat.exists
+
+- name: Ensure /var/run/nix dir exists
+  hosts: login, slurm_backup 
+  become: true
+  tasks:
+    - name: Does /var/run/nix dir exits
+      stat:
+        path: /var/run/nix
+      register: dir_stat
+    - name: Create /var/run/nix dir
+      file:
+        path: /var/run/nix
+        state: directory
+      when: not dir_stat.stat.exists
+
+- name: Mount /data/nix dir to /nix dir
+  hosts: all
+  gather_facts: true
+  become: true
+  tasks:
+    - include_role:
+        name: nfs-client
+      vars:
+        local_path: "/nix"
+        export_host: "{{ nfs_source_IP }}"
+        export_path: "/data/nix"
+        options: "{{ nfs_options }}"
+        lock: "none"
+
+- name: Link /var/run/nix and /data/nix/var/nix/daemon-socket dirs
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - name: Execute command
+      ansible.builtin.command: ln -s /var/run/nix /data/nix/var/nix/daemon-socket
+
+# install nix
+- name: Install Nix
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - name: Install Nix
+      include_role:
+        name: nix
+
+- name: Move nix.conf file
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - name: Move nix.conf file
+      command: mv /etc/nix/nix.conf /nix/nix.conf
+
+- name: Set Nix environment variables
+  hosts: login, slurm_backup
+  become: true
+  tasks:
+    - name: Set NIX_CONF_DIR environment variable
+      lineinfile:
+        path: /etc/bashrc
+        line: export NIX_CONF_DIR=/nix
+        create: yes
+
+- name: Add Nix binaries to path
+  hosts: login, bastion, compute
+  become: true
+  tasks:
+    - name: Add Nix binaries to /etc/bashrc file
+      lineinfile:
+        path: /etc/bashrc
+        line: export PATH=~/.nix-profile/bin:$PATH
+        create: yes
+
+- name: Add Nix tools to path
+  hosts: login
+  become: true
+  tasks:
+    - name: Add Nix tools to /etc/bashrc file
+      lineinfile:
+        path: /etc/bashrc
+        line: export PATH=/nix/var/nix/profiles/default/bin:$PATH
+        create: yes
+
+# setup socat tunnel
+- name: Install socat
+  hosts: login, slurm_backup
+  become: true
+  tasks:
+  - name: Install socat
+    vars: 
+      package_name: 
+        - socat
+      package_state: latest
+      package_repo: "epel,ol7_developer_EPEL"
+    include_role: 
+      name: safe_yum
+    ignore_errors: true
+
+- name: Set IP addresses in service unit files
+  hosts: bastion
+  become: true
+  tasks:
+    - name: Set ip address in server service unit file
+      replace:
+        path: /opt/oci-hpc/playbooks/roles/nix/files/socat-server.service
+        regexp: '\[slurm_backup_ip\]'
+        replace: "{{ hostvars[groups['slurm_backup'][0]].ansible_host }}"
+    - name: Set ip address in client service unit file
+      replace:
+        path: /opt/oci-hpc/playbooks/roles/nix/files/socat-client.service
+        regexp: '\[slurm_backup_ip\]'
+        replace: "{{ hostvars[groups['slurm_backup'][0]].ansible_host }}"
+
+- name: Setup socat server service
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - name: Copy socat server service unit file
+      copy: 
+        src: /opt/oci-hpc/playbooks/roles/nix/files/socat-server.service
+        dest: /etc/systemd/system
+    - name: Reload systemd
+      systemd: 
+        daemon_reload: true
+    - name: Enable the service
+      systemd:
+        name: socat-server.service
+        enabled: true
+        masked: no
+    - name: Start the service
+      systemd: 
+        name: socat-server.service
+        state: started
+
+- name: Setup socat client service 
+  hosts: login
+  become: true
+  tasks: 
+    - name: Copy socat client service unit file
+      copy: 
+        src: /opt/oci-hpc/playbooks/roles/nix/files/socat-client.service
+        dest: /etc/systemd/system
+    - name: Reload systemd
+      systemd: 
+        daemon_reload: true
+    - name: Enable the service
+      systemd:
+        name: socat-client.service
+        enabled: true
+        masked: no
+    - name: Start the service
+      systemd:
+        name: socat-client.service
+        state: started

--- a/playbooks/roles/nix/defaults/main.yml
+++ b/playbooks/roles/nix/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+nix_version: 2.15.0
+installer_checksum: sha512:b8d9a1bf8131bb0e81618cf24c46218fd8ece42bdf89598abcf4fe22531639ddaf03ad31458f2ac15f869e5cfe46c5ff6fd92ced7337a75501db7237b4bff281
+flakes: true

--- a/playbooks/roles/nix/files/socat-client.service
+++ b/playbooks/roles/nix/files/socat-client.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Socat Service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/socat unix-listen:/var/run/nix/socket,mode=666,fork tcp-connect:[slurm_backup_ip]:3324
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/roles/nix/files/socat-server.service
+++ b/playbooks/roles/nix/files/socat-server.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Socat Service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/socat TCP-LISTEN:3324,bind=[slurm_backup_ip],reuseaddr,fork,range=172.16.0.0/24 UNIX-CLIENT:/var/run/nix/socket
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/playbooks/roles/nix/tasks/main.yml
+++ b/playbooks/roles/nix/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Download and run installer
+  block:
+    - name: Download installer
+      get_url:
+        url: "{{ installer_path }}"
+        dest: /tmp
+        checksum: "{{ installer_checksum }}"
+    - name: extract installer
+      unarchive:
+        src: /tmp/{{ nix_build }}.tar.xz
+        remote_src: true
+        dest: /tmp/
+    - name: Run the installer
+      become: true
+      shell:
+        cmd: ./install --daemon </dev/null
+        chdir: /tmp/{{ nix_build }}
+
+- name: Enable flakes
+  become: true
+  lineinfile:
+    path: /etc/nix/nix.conf
+    line: "experimental-features = nix-command flakes"
+  when: flakes

--- a/playbooks/roles/nix/vars/main.yml
+++ b/playbooks/roles/nix/vars/main.yml
@@ -1,0 +1,3 @@
+---
+nix_build: nix-{{ nix_version }}-x86_64-linux
+installer_path: https://releases.nixos.org/nix/nix-{{ nix_version }}/{{ nix_build }}.tar.xz

--- a/playbooks/uninstall_nix.yml
+++ b/playbooks/uninstall_nix.yml
@@ -1,0 +1,201 @@
+--- 
+
+- name: Remove socat client service
+  hosts: login
+  become: true
+  tasks:
+    - name: Gather service facts
+      service_facts:
+    - name: Stop socat client service
+      systemd:
+        name: socat-client.service
+        enabled: false
+        state: stopped
+        daemon_reload: true
+      when: "'socat-client.service' in services"
+    - name: Remove socat client service unit file
+      file: 
+        path: /etc/systemd/system/socat-client.service
+        state: absent
+
+- name: Remove socat server service
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - name: Gather service facts
+      service_facts:
+    - name: Stop socat server service
+      systemd: 
+        name: socat-server.service
+        enabled: false
+        state: stopped
+        daemon_reload: true
+      when: "'socat-server.service' in services"
+    - name: Remove socat server service unit file
+      file: 
+        path: /etc/systemd/system/socat-server.service
+        state: absent
+
+- name: Remove nix daemon service
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - name: Gather service facts
+      service_facts:
+    - name: Stop nix daemon socket
+      systemd: 
+        name: nix-daemon.socket
+        enabled: false
+        state: stopped
+        daemon_reload: true
+    - name: Stop nix daemon service
+      systemd: 
+        name: nix-daemon.service
+        enabled: false
+        state: stopped
+        daemon_reload: true
+      when: "'nix-daemon.service' in services"
+    - name: Remove nix daemon socket unit file
+      file: 
+        path: /etc/systemd/system/nix-daemon.socket
+        state: absent
+    - name: Remove nix daemon service unit file
+      file:
+        path: /etc/systemd/system/nix-daemon.service
+        state: absent
+  ignore_errors: true
+  
+- name: Remove configuration files
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - file:
+        path: /etc/tmpfiles.d/nix-daemon.conf
+        state: absent
+
+- name: Unmount the /nix directory
+  hosts: login, bastion, slurm_backup, compute
+  become: true
+  tasks:
+    - name: Unmount
+      mount:
+        path: /nix
+        state: unmounted
+    - name: Remove references from /etc/fstab file
+      lineinfile:
+        path: /etc/fstab
+        state: absent
+        regexp: '{{ nfs_source_IP }}:\/data\/nix \/nix nfs defaults 0 0'
+
+- name: Remove Nix store from shared filesystem
+  hosts: bastion
+  become: true
+  tasks:
+    - name: Remove /data/nix dir
+      file: 
+        path: /data/nix
+        state: absent
+
+- name: Remove files and dirs created by Nix
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - name: Remove /nix dir
+      file: 
+        path: /nix
+        state: absent
+    - name: Remove /var/run/nix
+      file:
+        path: /var/run/nix
+        state: absent
+    - name: Remove /etc/nix dir
+      file: 
+        path: /etc/nix
+        state: absent
+    - name: Remove /etc/profile/nix.sh file
+      file:
+        path: /etc/profile/nix.sh
+        state: absent
+    - name: Remove ~root/.nix-profile dir
+      file: 
+        path: ~root/.nix-profile
+        state: absent
+    - name: Remove ~root/.nix-defexpr dir
+      file: 
+        path: ~root/.nix-defexpr 
+        state: absent
+    - name: Remove ~root/.nix-channels
+      file:
+        path: ~root/.nix-channels
+        state: absent
+    - name: Remove ~/.nix-profile dir
+      file:
+        path: ~/.nix-profile
+        state: absent
+    - name: Remove ~/.nix-defexpr dir
+      file:
+        path: ~/.nix-defexpr 
+        state: absent
+    - name: Remove ~/.nix-channels dir
+      file:
+        path: ~/.nix-channels
+        state: absent
+    - name: Remove /etc/profile.d/nix.sh
+      file: 
+        path: /etc/profile.d/nix.sh
+        state: absent
+    - name: Remove /etc/bashrc.backup-before-nix
+      file:
+        path: /etc/bashrc.backup-before-nix
+        state: absent
+    - name: Remove /etc/zshrc.backup-before-nix
+      file: 
+        path: /etc/zshrc.backup-before-nix
+        state: absent
+    - name: Remove /etc/bash.bashrc.backup-before-nix
+      file: 
+        path: /etc/bash.bashrc.backup-before-nix
+        state: absent
+
+- name: Remove build users and their group
+  hosts: slurm_backup
+  become: true
+  tasks:
+    - name: Remove nixbld users
+      shell: |
+        for i in $(seq 1 32); do
+          userdel nixbld$i
+        done
+    - name: Remove nixbld group
+      shell: groupdel nixbld
+  ignore_errors: true
+
+- name: Remove references to Nix
+  hosts: login, bastion, slurm_backup, compute
+  become: true
+  tasks:
+    - name: Remove line from /etc/bashrc file
+      lineinfile:
+        path: /etc/bashrc
+        state: absent
+        regexp: '^export NIX_CONF_DIR=/nix$'
+    - name: Remove line from /etc/bashrc file
+      lineinfile:
+        path: /etc/bashrc
+        state: absent
+        regexp: '# Nix.*|# End Nix'
+    - name: Remove line from /etc/bash.bashrc file
+      lineinfile:
+        path: /etc/bash.bashrc
+        state: absent
+        regexp: '# Nix.*|# End Nix'
+    - name: Remove line from /etc/bashrc file
+      lineinfile: 
+        path: /etc/bashrc
+        state: absent
+        regexp: '^export PATH=~/.nix-profile/bin:\$PATH$'
+    - name: Remove line from /etc/bashrc file
+      lineinfile:
+        path: /etc/bashrc
+        state: absent
+        regexp: '^export PATH=/nix/var/nix/profiles/default/bin:\$PATH$'


### PR DESCRIPTION
I deployed in San Jose and ran the following tests:
Before I install Nix, I need to create a user to test whether Nix gets added to existing users. 
0. Install Nix
```
# run on bastion
# edit socat-server.service and socat-client.service files with the correct ip address
cd /opt/oci-hpc/playbook
ansible-playbook install_nix.yml
```
1. Make sure Nix is installed 
``` 
# run on login and backup
nix doctor
# expected output
[PASS] PATH contains only one nix version.
[PASS] All profiles are gcroots.
[PASS] Client protocol matches store protocol.
[INFO] You are trusted by store uri: daemon
…
```
2. Install a package
``` 
# run on login
nix profile install nixpkgs#hello
# test package
hello
>Hello, world!
```
3. Test package on different node
```
# run on bastion
hello
>Hello, world!
```
4. Repeat tests 1-3 as a user
5. Uninstall nix
```
# run on bastion
cd /opt/oci-hpc/playbooks
ansible-playbooks uninstall_nix.yml
```
