### PR TITLE
remove devtoolset-5 from cais compute playbook

### DIFF
--- a/playbooks/roles/cais-compute/tasks/ol-7.yml
+++ b/playbooks/roles/cais-compute/tasks/ol-7.yml
@@ -40,19 +40,6 @@
   include_role: 
     name: safe_yum
   ignore_errors: true
-- name: Install SCL for GCC v5
-  vars: 
-    package_name: 
-      - devtoolset-5-gcc.x86_64
-      - devtoolset-5-gcc-c++.x86_64
-      - devtoolset-5-gcc-gdb-plugin.x86_64
-      - devtoolset-5-gcc-gfortran.x86_64
-      - devtoolset-5-gcc-plugin-devel.x86_64
-    package_state: latest
-    package_repo: "epel,ol7_developer_EPEL"
-  include_role: 
-    name: safe_yum
-  ignore_errors: true
 - name: Install SCL for GCC v6
   vars: 
     package_name: 


### PR DESCRIPTION
Removed the play that installs `devtoolset-5`. 