### PR TITLE
Adds opengl/mesa to cais-compute ansible role

### DIFF
--- a/playbooks/roles/cais-compute/tasks/ol-7.yml
+++ b/playbooks/roles/cais-compute/tasks/ol-7.yml
@@ -105,6 +105,20 @@
   include_role:
     name: safe_yum
   ignore_errors: true
+- name: Install openGL/Mesa
+  vars:
+    package_name:
+      - mesa-libOSMesa.x86_64
+      - mesa-libOSMesa-devel.x86_64
+      - glfw.x86_64
+      - glfw-devel.x86_64
+      - mesa-libGL.x86_64
+      - mesa-libGL-devel.x86_64
+    package_state: latest
+    package_repo: "epel,ol7_developer_EPEL"
+  include_role:
+    name: safe_yum
+  ignore_errors: true
 
 # Used for local storage
 - name: Create local storage location for all compute nodes


### PR DESCRIPTION
Ran `ansible-playbook cais_*` to install packages.

Ran the following ansible playbook to make sure that packages are present on all compute nodes:
```
---

- name: Check if package is installed
  hosts: compute
  become: true
  tasks:
    - name: Gather the package facts
      ansible.builtin.package_facts:
        manager: auto
#    - name: Print the package facts
#      ansible.builtin.debug:
#        var: ansible_facts.packages
    - name: Check whether the package mesa-libOSMesa  is installed
      ansible.builtin.debug:
        msg: "{{ ansible_facts.packages['mesa-libOSMesa'] | length }} versions of mesa-libOSMesa are installed!"
      when: "'mesa-libOSMesa' in ansible_facts.packages"
    - name: Check whether the package mesa-libOSMesa-devel is installed
      ansible.builtin.debug:
        msg: "{{ ansible_facts.packages['mesa-libOSMesa-devel'] | length }} versions of mesa-libOSMesa-devel are installed!"
      when: "'mesa-libOSMesa-devel' in ansible_facts.packages"
    - name: Check whether the package glfw is installed
      ansible.builtin.debug:
        msg: "{{ ansible_facts.packages['glfw'] | length }} versions of glfw are installed!"
      when: "'glfw' in ansible_facts.packages"
    - name: Check whether the package glfw-devel is installed
      ansible.builtin.debug:
        msg: "{{ ansible_facts.packages['glfw-devel'] | length }} versions of glfw-devel are installed!"
      when: "'glfw-devel' in ansible_facts.packages"
    - name: Check whether the package mesa-libGL is installed
      ansible.builtin.debug:
        msg: "{{ ansible_facts.packages['mesa-libGL'] | length }} versions of mesa-libGL are installed!"
      when: "'mesa-libGL' in ansible_facts.packages"
    - name: Check whether the package mesa-libGL-devel is installed
      ansible.builtin.debug:
        msg: "{{ ansible_facts.packages['mesa-libGL-devel'] | length }} versions of mesa-libGL-devel are installed!"
      when: "'mesa-libGL-devel' in ansible_facts.packages"
```

Results("ok" means that the packages are present): 
```
PLAY RECAP ************************************************************************************************************************************************************************
inst-1izto-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-3lkhl-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-4550h-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-4aqno-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-7vnv6-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-aa2un-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-bmccd-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-cpqls-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-e6vvd-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-encjw-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-evoyb-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-fnbev-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-fwhck-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-gp7wn-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-hgqwx-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-hsfgo-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-mdqbh-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-necvh-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-nfanw-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-qj9qc-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-rbxtc-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-rk4hy-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-u90mk-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-ul7as-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-umizk-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-unr7l-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-vjaro-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-wzlds-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-xydnk-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-yajr3-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-ysctj-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
inst-yum8n-watch-tower     : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```