### PR TITLE
removes broken play from cais-compute role

### DIFF
--- a/playbooks/roles/cais-compute/tasks/ol-7.yml
+++ b/playbooks/roles/cais-compute/tasks/ol-7.yml
@@ -31,15 +31,6 @@
   include_role: 
     name: safe_yum
   ignore_errors: true
-- name: Install llvm
-  vars: 
-    package_name: 
-      - llvm-toolset-7.0
-    package_state: latest
-    package_repo: "epel,ol7_developer_EPEL"
-  include_role: 
-    name: safe_yum
-  ignore_errors: true
 - name: Install SCL for GCC v6
   vars: 
     package_name: 


### PR DESCRIPTION
Deployed Dev Cpu Cluster and ran `ansible-playbook cais_*` which runs the cais-compute role. No errors.

```
PLAY RECAP ****************************************************************************************************************************************************************************************************************************************
dev-backup                 : ok=16   changed=11   unreachable=0    failed=0    skipped=21   rescued=0    ignored=0   
dev-bastion                : ok=19   changed=12   unreachable=0    failed=0    skipped=30   rescued=0    ignored=0   
dev-login                  : ok=19   changed=12   unreachable=0    failed=0    skipped=30   rescued=0    ignored=0   
inst-bqrwz-dev             : ok=36   changed=20   unreachable=0    failed=0    skipped=78   rescued=0    ignored=0   
inst-y01kv-dev             : ok=36   changed=20   unreachable=0    failed=0    skipped=78   rescued=0    ignored=0   

```