### PR TITLE
205 migrate nix to weka

### DIFF
--- a/playbooks/install_nix.yml
+++ b/playbooks/install_nix.yml
@@ -51,19 +51,17 @@
         state: directory
       when: not dir_stat.stat.exists
 
-- name: Mount /data/nix dir to /nix dir
+- name: Bind mount /data/nix dir to /nix dir
   hosts: all
   gather_facts: true
   become: true
   tasks:
-    - include_role:
-        name: nfs-client
-      vars:
-        local_path: "/nix"
-        export_host: "{{ nfs_source_IP }}"
-        export_path: "/data/nix"
-        options: "{{ nfs_options }}"
-        lock: "none"
+    - mount:
+        path: /nix
+        src: /data/nix
+        fstype: none
+        opts: bind
+        state: mounted
 
 - name: Link /var/run/nix and /data/nix/var/nix/daemon-socket dirs
   hosts: slurm_backup

--- a/playbooks/uninstall_nix.yml
+++ b/playbooks/uninstall_nix.yml
@@ -85,7 +85,7 @@
       lineinfile:
         path: /etc/fstab
         state: absent
-        regexp: '{{ nfs_source_IP }}:\/data\/nix \/nix nfs defaults 0 0'
+        regexp: '{{\/data\/nix \/nix none bind 0 0'
 
 - name: Remove Nix store from shared filesystem
   hosts: bastion

--- a/playbooks/uninstall_nix.yml
+++ b/playbooks/uninstall_nix.yml
@@ -85,7 +85,7 @@
       lineinfile:
         path: /etc/fstab
         state: absent
-        regexp: '{{\/data\/nix \/nix none bind 0 0'
+        regexp: '\/data\/nix \/nix none bind 0 0'
 
 - name: Remove Nix store from shared filesystem
   hosts: bastion


### PR DESCRIPTION
Updated the nix install and uninstall playbooks to work with wekafs. The playbooks still work with the FSS but now no longer reference the FSS so they work with any shared file system. Tested both playbooks on a dev cluster. 