### PR TITLE
Added playbooks to enable and disable passwordless ssh for root user.

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -17,3 +17,17 @@ To install notifications run the notifications_install.yml and enter the slack_b
 For the webhooks go to [slack bot app](https://app.slack.com/app-settings/T04PVJTPVCJ/A05AGQ7HNBX) then Incoming Webhooks. Press Add new Webhook to Workspace at the bottom and select the channel you want notified for admin notifications. Copy the webhook and enter it when prompted during the above install
 
 To uninstall notifications run notifications_uninstall.yml. Note that this does not remove the MailProg entry from the slurm.conf. This won't cause problems but will be silently erroring in the slurmctld.log. So if you want to be clean you can remove that from the config.
+
+## Passwordless SSH for Root User
+
+We provide playbooks to enable and disable passwordless SSH for the root user. This feature is typically required for automated administrative tasks such as software upgrades, for example with Weka. Caution: Enabling passwordless SSH for the root user poses significant security risks. Be sure to disable it as soon as it is no longer necessary.
+
+Prerequisites:
+- Ensure that SSH key pairs (root and root.pub) are created. If you haven’t already, you can generate them using the following command: `ssh-keygen -f /home/opc/.ssh/root -N ''`
+- Place the keys in the /home/opc/.ssh/ directory.
+
+Enabling Passwordless SSH: `ansible-playbook passwordless_ssh_for_root_enable.yml`
+
+Disabling Passwordless SSH: `ansible-playbook passwordless_ssh_for_root_disable.yml`
+
+Note: Always ensure that passwordless SSH is disabled when not actively needed to maintain the security integrity of your system.

--- a/playbooks/passwordless_ssh_for_root_disable.yml
+++ b/playbooks/passwordless_ssh_for_root_disable.yml
@@ -1,0 +1,57 @@
+---
+- name: Disable passwordless SSH for root user
+  hosts: all
+  become: true
+  tasks:
+    - name: Ensure the SSH directory exists
+      file:
+        path: /root/.ssh
+        state: directory
+        owner: root
+        group: root
+        mode: '0700'
+      ignore_errors: true
+
+    - name: Ensure the authorized_keys file exists
+      file:
+        path: /root/.ssh/authorized_keys
+        state: touch
+        owner: root
+        group: root
+        mode: '0600'
+      ignore_errors: true
+
+    - name: Remove the root's public key from the authorized_keys file
+      lineinfile:
+        path: /root/.ssh/authorized_keys
+        state: absent
+        line: "{{ lookup('file', '/home/{{ ansible_user }}/.ssh/root.pub') }}"
+      ignore_errors: true
+
+    - name: Remove the private key file
+      file:
+        path: "/root/.ssh/root"
+        state: absent
+      ignore_errors: true
+
+    - name: Ensure there is at least one newline at the end of the file
+      lineinfile:
+        path: "/root/.ssh/authorized_keys"
+        line: ''
+        create: no
+        insertafter: EOF
+
+    - name: Remove extra newlines from the end of the file
+      command: sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' /root/.ssh/authorized_keys
+      args:
+        warn: false
+
+- name: Remove specific warning from /etc/issue.net file
+  hosts: bastion
+  become: true  # Ensure you have administrative privileges
+  tasks:
+    - name: Remove warning message from /etc/issue.net
+      lineinfile:
+        path: /etc/issue.net
+        line: 'Warning: Passwordless SSH is enabled for root user.'
+        state: absent

--- a/playbooks/passwordless_ssh_for_root_enable.yml
+++ b/playbooks/passwordless_ssh_for_root_enable.yml
@@ -1,0 +1,51 @@
+---
+- name: Update /etc/issue.net file
+  hosts: bastion
+  become: true  # Ensure you have administrative privileges
+  tasks:
+    - name: Add warning message to /etc/issue.net
+      lineinfile:
+        path: /etc/issue.net
+        line: 'Warning: Passwordless SSH is enabled for root user.'
+        create: yes  # Create the file if it does not exist
+        state: present
+
+- name: Setup passwordless SSH for root user
+  hosts: all
+  become: true
+  tasks:
+    - name: Ensure the SSH directory exists
+      file:
+        path: "/root/.ssh"
+        state: directory
+        owner: root
+        group: root
+        mode: '0700'
+
+    - name: Read the public key from the file
+      slurp:
+        src: "/home/{{ ansible_user }}/.ssh/root.pub"
+      register: public_key
+
+    - name: Convert the public key to a string
+      set_fact:
+        pubkey_content: "{{ public_key['content'] | b64decode }}"
+
+    - name: Append the public key to the authorized_keys file
+      lineinfile:
+        path: "/root/.ssh/authorized_keys"
+        line: "{{ pubkey_content }}"
+        create: yes
+        owner: root
+        group: root
+        mode: '0600'
+        state: present
+
+    - name: Copy the private key to the SSH directory
+      copy:
+        src: "/home/{{ ansible_user }}/.ssh/root"
+        dest: "/root/.ssh/id_rsa"
+        owner: root
+        group: root
+        mode: '0600'
+


### PR DESCRIPTION
Tested on dev cluster. 
- Created SSH key pair for root.
- Ran playbook to enable password less ssh for root.
- Became root, SSH'd to all other nodes on the cluster (login, backup, two compute nodes).
- Ran playbook to disable password less ssh for root.
- Became root, confirmed I can no longer SSH to all other nodes on the cluster.