### PR TITLE
Added monitoring backups.

### DIFF
--- a/playbooks/roles/backups/files/monitoring_backup.sh
+++ b/playbooks/roles/backups/files/monitoring_backup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# --- Configuration -------------------------------------------------
+LOG_FILE="/opt/oci-hpc/logs/backups/monitoring_backup.log"
+CREDENTIALS_FILE="/etc/credentials"
+
+VM_BACKUP_CMD=(
+  "/usr/bin/vmbackup"
+  "-storageDataPath=/home/ubuntu/utils/victoria_metrics/data/"
+  "-snapshot.createURL=http://localhost:8428/snapshot/create"
+  "-credsFilePath=$CREDENTIALS_FILE"
+  "-dst=s3://backups/victoria_metrics"
+  "-customS3Endpoint=axvscsfozusv.compat.objectstorage.us-sanjose-1.oraclecloud.com"
+)
+
+# --- Logging setup -------------------------------------------------
+# All script output (stdout and stderr) will be appended to $LOG_FILE.
+exec >> "$LOG_FILE" 2>&1
+
+# --- Functions -----------------------------------------------------
+# Logs a message with a timestamp.
+log() {
+  echo "$(date +"%Y-%m-%d %H:%M:%S") - $*"
+}
+
+# --- Main ----------------------------------------------------------
+# Check if the credentials file exists
+if [ ! -f "$CREDENTIALS_FILE" ]; then
+  log "ERROR: Credentials file '$CREDENTIALS_FILE' not found. Backup cannot proceed."
+  exit 1
+fi
+
+log "INFO: Starting vmbackup..."
+
+# Execute the vmbackup command
+if sudo "${VM_BACKUP_CMD[@]}"; then
+  log "INFO: vmbackup completed successfully."
+else
+  log "ERROR: vmbackup encountered an error. Please check the log for details."
+  exit 1
+fi
+
+exit 0

--- a/playbooks/roles/backups/tasks/main.yml
+++ b/playbooks/roles/backups/tasks/main.yml
@@ -9,3 +9,4 @@
 - include_tasks: ldap.yml
 - include_tasks: accounting.yml
 - include_tasks: slurm.yml
+- include_tasks: monitoring.yml

--- a/playbooks/roles/backups/tasks/monitoring.yml
+++ b/playbooks/roles/backups/tasks/monitoring.yml
@@ -1,0 +1,39 @@
+---
+- name: Install Victoria Metrics
+  vars: 
+    package_name: 
+      - victoria-metrics
+    package_state: latest
+    package_repo: "epel,ol7_developer_EPEL"
+  include_role: 
+    name: safe_yum
+  ignore_errors: true
+
+# We are using the dockerized version of victoria metrics so disable the systemd version should be disabled
+- name: Disable and stop the Victoria Metrics service
+  become: true
+  systemd:
+    name: victoria-metrics
+    enabled: no
+    state: stopped
+
+- name: Copy scripts
+  become: true
+  copy: 
+    src: '{{ item }}'
+    dest: '/opt/oci-hpc/scripts/{{ item }}'
+    force: no
+    owner: '{{ ansible_user }}'
+    group: '{{ ansible_user }}'
+    mode: 0770
+  with_items:
+    - monitoring_backup.sh
+
+- name: Create crontab entry to backup monitoring
+  cron:
+    name: Backup monitoring
+    minute: "0"
+    hour: "0"
+    user: '{{ ansible_user }}'
+    job: "/opt/oci-hpc/scripts/monitoring_backup.sh"
+    disabled: true


### PR DESCRIPTION
Tested on a dev cluster.
- Imported test data from export of production data to dev cluster
- Performed a backup from dev cluster to backups bucket by running `/opt/oci-hpc/scripts/monitoring_backup.sh`
- Cleared all monitoring data from dev cluster
- Restored monitoring data from backup

When backing up stdout will looks something like this when completed successfully
```bash
//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"}
2025-01-10T22:43:20.691Z	info	VictoriaMetrics/lib/backup/actions/backup.go:146	uploading part{path: "indexdb/17EE1C7F6927BC8E/17F00378D4EA2C82/items.bin", file_size: 711, offset: 0, size: 711} from src fslocal "/home/ubuntu/utils/victoria_metrics/data//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"}
2025-01-10T22:43:20.691Z	info	VictoriaMetrics/lib/backup/actions/backup.go:146	uploading part{path: "indexdb/17EE1C7F6927BC8E/17F00378D4EA2C82/lens.bin", file_size: 167, offset: 0, size: 167} from src fslocal "/home/ubuntu/utils/victoria_metrics/data//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"}
2025-01-10T22:43:20.700Z	info	VictoriaMetrics/lib/backup/actions/backup.go:146	uploading part{path: "indexdb/17EE1C7F6927BC8E/17F00378D4EA2C82/metadata.json", file_size: 388, offset: 0, size: 388} from src fslocal "/home/ubuntu/utils/victoria_metrics/data//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"}
2025-01-10T22:43:20.703Z	info	VictoriaMetrics/lib/backup/actions/backup.go:146	uploading part{path: "indexdb/17EE1C7F6927BC8E/17F00378D4EA2C82/metaindex.bin", file_size: 60, offset: 0, size: 60} from src fslocal "/home/ubuntu/utils/victoria_metrics/data//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"}
2025-01-10T22:43:24.587Z	info	VictoriaMetrics/lib/backup/actions/backup.go:164	uploaded 161907999376 out of 162584560359 bytes from src fslocal "/home/ubuntu/utils/victoria_metrics/data//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"} in 7m0.00034305s
2025-01-10T22:43:34.587Z	info	VictoriaMetrics/lib/backup/actions/backup.go:164	uploaded 162474451819 out of 162584560359 bytes from src fslocal "/home/ubuntu/utils/victoria_metrics/data//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"} in 7m10.000760916s
2025-01-10T22:43:37.579Z	info	VictoriaMetrics/lib/backup/actions/backup.go:164	uploaded 162584560359 out of 162584560359 bytes from src fslocal "/home/ubuntu/utils/victoria_metrics/data//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"} in 7m12.99238721s
2025-01-10T22:43:37.579Z	info	VictoriaMetrics/lib/backup/actions/backup.go:171	backup from src fslocal "/home/ubuntu/utils/victoria_metrics/data//snapshots/20250110223613-181974FB51689C44" to dst S3{bucket: "backups", dir: "victoria_metrics/"} with origin fsnil is complete; backed up 162584560359 bytes in 434.483 seconds; deleted 0 bytes; server-side copied 0 bytes; uploaded 162584560359 bytes
2025-01-10T22:43:37.595Z	info	VictoriaMetrics/app/vmbackup/main.go:104	gracefully shutting down http server for metrics at ":8420"
2025-01-10T22:43:37.598Z	info	VictoriaMetrics/app/vmbackup/main.go:108	successfully shut down http server for metrics in 0.002 seconds
2025-01-10T22:43:37.598Z	info	VictoriaMetrics/app/vmbackup/snapshot/snapshot.go:58	Deleting snapshot 20250110223613-181974FB51689C44
2025-01-10T22:43:41.755Z	info	VictoriaMetrics/app/vmbackup/snapshot/snapshot.go:85	Snapshot 20250110223613-181974FB51689C44 deleted
2025-01-10 22:43:41 - INFO: vmbackup completed successfully.
```