### PR TITLE
sets public IP assignment to false

### DIFF
--- a/instance-pool-configuration.tf
+++ b/instance-pool-configuration.tf
@@ -9,6 +9,9 @@ resource "oci_core_instance_configuration" "instance_pool_configuration" {
     launch_details {
       availability_domain = var.ad
       compartment_id      = var.targetCompartment
+      create_vnic_details {
+        assign_public_ip = false
+      }
       display_name = local.cluster_name
       freeform_tags = {
         "cluster_name"   = local.cluster_name


### PR DESCRIPTION
This is the change andriy and I made that made deployment of VM stack on jason compartment work.
Here's the issue: #360 

Because by default it uses a public IP for a private subnet, setting this to false seemed to make it work. 
Feedback data was correlational, but we didn't change anything else in the stack config before / after change.