### PR TITLE
Fix cpuspec list in jinja template

### DIFF
--- a/playbooks/roles/slurm/templates/systemd/slurmd.service.d/unit.conf.j2
+++ b/playbooks/roles/slurm/templates/systemd/slurmd.service.d/unit.conf.j2
@@ -49,4 +49,5 @@ ExecStart=
 {% else %}
 {% set gres = "" %}
 {% endif %}
+
 ExecStart={{slurm_exec}}/sbin/slurmd --systemd -Z --conf "{{gres}} Feature={{instance_type}},CN__{{cluster_name}}" --conf-server {{ hostvars[groups['controller'][0]]['ansible_fqdn'].split('.')[0] }}{% if (groups['slurm_backup']| length ) > 0 %},{{ hostvars[groups['slurm_backup'][0]]['ansible_fqdn'].split('.')[0] }}{% endif %} $SLURMD_OPTIONS


### PR DESCRIPTION
We recently made changes to cpuspeclist on prod to match weka reserved cores. This should also be fixed by site.yml, which pulls up this unit.conf.j2 template.