### PR TITLE
Changes logrotation from daily to weekly

### DIFF
--- a/playbooks/roles/cais-compute/templates/slurmd-logrotate
+++ b/playbooks/roles/cais-compute/templates/slurmd-logrotate
@@ -1,5 +1,5 @@
 /var/log/slurm/slurmd.log {
-    daily
+    weekly
     rotate 5
     compress
     missingok

--- a/playbooks/roles/cais-controller-login/templates/slurmctld-logrotate
+++ b/playbooks/roles/cais-controller-login/templates/slurmctld-logrotate
@@ -1,5 +1,5 @@
 /var/log/slurm/slurmctld.log {
-    daily
+    weekly
     rotate 5
     compress
     missingok

--- a/playbooks/roles/cais-controller-login/templates/slurmdbd-logrotate
+++ b/playbooks/roles/cais-controller-login/templates/slurmdbd-logrotate
@@ -1,5 +1,5 @@
 /var/log/slurm/slurmdbd.log {
-    daily
+    weekly
     rotate 5
     compress
     missingok


### PR DESCRIPTION
The location of these logrotation configs that are modified:
```
playbooks/roles/cais-compute/templates/slurmd-logrotate
playbooks/roles/cais-controller-login/templates/slurmctld-logrotate
playbooks/roles/cais-controller-login/templates/slurmdbd-logrotate
```

