### PR TITLE
reduces retries in site.yml sub-tasks

### DIFF
--- a/playbooks/roles/fix_broken/tasks/ubuntu.yml
+++ b/playbooks/roles/fix_broken/tasks/ubuntu.yml
@@ -4,7 +4,7 @@
   become: true
   shell: ps aux | grep "apt update" | grep -v grep | wc -l
   register: result
-  retries: 30
+  retries: 10
   delay: 10
   until: result.stdout | int == 0
 
@@ -22,7 +22,7 @@
   become: true
   shell: ps aux | grep "apt update" | grep -v grep | wc -l
   register: result
-  retries: 30
+  retries: 10
   delay: 10
   until: result.stdout | int == 0
 
@@ -50,7 +50,7 @@
   become: true
   shell: ps aux | grep "apt update" | grep -v grep | wc -l
   register: result
-  retries: 30
+  retries: 10
   delay: 10
   until: result.stdout | int == 0
 
@@ -69,7 +69,7 @@
   become: true
   shell: ps aux | grep "apt update" | grep -v grep | wc -l
   register: result
-  retries: 30
+  retries: 10
   delay: 10
   until: result.stdout | int == 0
 
@@ -78,7 +78,7 @@
   file: 
     path: "/var/lib/apt/lists/lock"
     state: absent
-  retries: 30
+  retries: 10
   delay: 10
   until: result.stdout | int == 0
 

--- a/playbooks/roles/safe_yum/tasks/el.yml
+++ b/playbooks/roles/safe_yum/tasks/el.yml
@@ -21,7 +21,7 @@
         jid: "{{ yum_sleeper.ansible_job_id }}"
       register: job_result
       until: job_result.finished
-      retries: 30
+      retries: 10
       delay: 10
       when: not ansible_check_mode and (package_repo|default('None') != 'None')
       failed_when: job_result.rc is defined and job_result.rc > 0 and not 'could not find job' in job_result.msg
@@ -45,7 +45,7 @@
         jid: "{{ yum_sleeper.ansible_job_id }}"
       register: job_result
       until: job_result.finished
-      retries: 30
+      retries: 10
       delay: 10
       when: package_repo|default('None') == 'None'
       failed_when: job_result.rc is defined and job_result.rc > 0 and not 'could not find job' in job_result.msg
@@ -71,7 +71,7 @@
         disable_gpg_check: "{{ disable_gpg_check_var| default('false') | bool}}"
         allow_downgrade: "{{ package_allow_downgrade | default('false') | bool }}"
       register: packages_output
-      retries: 5
+      retries: 10
       delay: 10
       until: packages_output is not failed
       when: package_repo|default('None') != 'None'
@@ -85,7 +85,7 @@
         lock_timeout: 90
         allow_downgrade: "{{ package_allow_downgrade | default('false') | bool }}"
       register: packages_output
-      retries: 5
+      retries: 10
       delay: 10
       until: packages_output is not failed
       when: package_repo|default('None') == 'None'

--- a/playbooks/roles/safe_yum/tasks/ubuntu.yml
+++ b/playbooks/roles/safe_yum/tasks/ubuntu.yml
@@ -3,7 +3,7 @@
   become: true
   shell: ps aux | grep "apt update" | grep -v grep | wc -l
   register: result
-  retries: 30
+  retries: 5
   delay: 10
   until: result.stdout | int == 0
 
@@ -16,7 +16,7 @@
     update_cache: "{{package_cache | default('false')}}"
   register: result
   until: result is not failed
-  retries: 5
+  retries: 10
   delay: 5
   when: not deb_name is defined
 
@@ -29,7 +29,7 @@
     update_cache: "{{package_cache | default('false')}}"
   register: result
   until: result is not failed
-  retries: 5
+  retries: 10
   delay: 5
   when: deb_name is defined
   with_items: "{{deb_name}}"
@@ -39,6 +39,6 @@
   become: true
   shell: ps aux | grep "apt update" | grep -v grep | wc -l
   register: result
-  retries: 30
+  retries: 5
   delay: 10
   until: result.stdout | int == 0


### PR DESCRIPTION
I kept retries: 5 on the lightweight guard tasks that just wait for apt locks to clear, while anything that actually performs installs/removals now uses retries: 10, so longer operations still have a bit of patience without the 30 retries which took a really long time for no reason.

Before reducing retries
- site.yml took 17 minutes
After reducing retries
- site.yml takes 7 minutes.

```
PLAY RECAP *********************************************************************************************************************************************************************************
inst-aovte-top-gorilla     : ok=346  changed=79   unreachable=0    failed=0    skipped=150  rescued=0    ignored=1
inst-wu7n0-top-gorilla     : ok=331  changed=72   unreachable=0    failed=0    skipped=148  rescued=0    ignored=1
top-gorilla-controller     : ok=416  changed=73   unreachable=0    failed=0    skipped=175  rescued=0    ignored=1
top-gorilla-login          : ok=228  changed=44   unreachable=0    failed=0    skipped=112  rescued=0    ignored=1
```