### PR TITLE
Shortens tmp duster frequency to every 5 minutes, removes redundant privilege escalation

### DIFF
--- a/playbooks/roles/cais-all/tasks/ubuntu.yml
+++ b/playbooks/roles/cais-all/tasks/ubuntu.yml
@@ -32,14 +32,11 @@
     owner: root
     group: root
     mode: '0755'
-  become: true
 
 - name: Ensure tmp cleanup runs hourly
   become: true
   cron:
     name: tmp directory cleanup
-    special_time: hourly
     user: ubuntu
+    minute: "*/5"    
     job: "/usr/local/sbin/tmp-duster.sh"
-  become: true
-  


### PR DESCRIPTION
This addresses a fix Steven suggested:
- to change frequency of tmp-duster from every hour to 5 minutes
- removes redundant `become: true`

The cron job is also changed in all compute nodes and controller. 