### PR TITLE
Exempts user for the reaper

### DIFF
--- a/playbooks/roles/cais-all/templates/idle-job-reaper.py
+++ b/playbooks/roles/cais-all/templates/idle-job-reaper.py
@@ -91,7 +91,7 @@ class GPUJobReaper:
     def get_job_info(self, job_id: int) -> Dict:
         try:
             result = subprocess.run(
-                ["sudo", "scontrol", "show", "job", str(job_id), "--json=v0.0.40"],
+                ["scontrol", "show", "job", str(job_id), "--json=v0.0.40"],
                 capture_output=True,
                 text=True,
                 check=True
@@ -154,7 +154,7 @@ class GPUJobReaper:
         try:
             admin_comment = f"GPU utilization below threshold of {self.min_util} for {self.window_min} minutes"
             subprocess.run(
-                ["scontrol", "update", f"job={job_id}", f"AdminComment={admin_comment}"],
+                ["sudo", "scontrol", "update", f"job={job_id}", f"AdminComment={admin_comment}"],
                 check=True
             )
 


### PR DESCRIPTION
Adds the User and Job Exemptions. 

I only made the User exemption for Mantas on Prod, and job exemption was already done.

Adds a new argument to should_reap_job(), user_name, which is extracted from job_info["owner"].

The EXEMPT_USERS variable should contain strings, with the slurm user_name for the person.